### PR TITLE
Feature-IOPS-2817-Update-Tumour-Cellularity-Examples

### DIFF
--- a/ConceptMap/ConceptMap-Genomics-specimen-tumourcellularity.json
+++ b/ConceptMap/ConceptMap-Genomics-specimen-tumourcellularity.json
@@ -20,7 +20,7 @@
     }
   ],
   "description": "A ConceptMap used for the translation and recording of concepts from MDS source data(code-options) to equivalent Snomed CT codes, and FHIR spec.",
-  "purpose": "ConceptMap used for the translation and recording of concepts for the proportion of tumour cellularity. This is intended for the element Observation.component.valueCodeableConcept.",
+  "purpose": "ConceptMap used for the translation and recording of concepts for the proportion of tumour cellularity. This is intended for the element Observation.valueCodeableConcept.",
   "copyright": "Copyright © 2023+ NHS England Licensed under the Apache License, Version 2.0 (the \\\"License\\\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \\\"AS IS\\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. HL7® FHIR® standard Copyright © 2011+ HL7 The HL7® FHIR® standard is used under the FHIR license. You may obtain a copy of the FHIR license at  https://www.hl7.org/fhir/license.html.",
   "targetUri": "http://snomed.info/sct?fhir_vs=ecl/%3C!%20362981000%20",
   "group": [

--- a/Observation/Observation-BlastPercentage-Example.json
+++ b/Observation/Observation-BlastPercentage-Example.json
@@ -36,17 +36,14 @@
     "system": "http://unitsofmeasure.org",
     "code": "%"
   },
-  "interpretation": [
-    {
-      "text": "Cellularity",
-      "coding": [
-        {
-          "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-          "code": "H",
-          "display": "High"
-        }
-      ]
-    }
-  ],
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+        "code": "H",
+        "display": "High"
+      }
+    ]
+  },
   "effectiveDateTime": "2023-08-29"
 }

--- a/Observation/Observation-Cellularity-Example.json
+++ b/Observation/Observation-Cellularity-Example.json
@@ -3,7 +3,7 @@
   "id": "Observation-Cellularity-Example",
   "status": "final",
   "code": {
-    "text":"Cellularity"
+    "text": "Cellularity"
   },
   "subject": {
     "reference": "Patient/Patient-ZelmaHadjkiss-Example",
@@ -18,16 +18,14 @@
       "value": "RA257630"
     }
   },
- "interpretation": [
-    {
-      "coding": [
-        {
-          "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-          "code": "H",
-          "display": "High"
-        }
-      ]
-    }
-  ],
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+        "code": "H",
+        "display": "High"
+      }
+    ]
+  },
   "effectiveDateTime": "2023-09-08T10:00:00Z"
 }

--- a/Observation/Observation-CellularityKayBurbridge-Example.json
+++ b/Observation/Observation-CellularityKayBurbridge-Example.json
@@ -18,16 +18,14 @@
       "value": "699F01231423"
     }
   },
- "interpretation": [
-    {
-      "coding": [
-        {
-          "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-          "code": "H",
-          "display": "High"
-        }
-      ]
-    }
-  ],
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+        "code": "H",
+        "display": "High"
+      }
+    ]
+  },
   "effectiveDateTime": "2023-11-01T11:00:00Z"
 }

--- a/Observation/Observation-CellularityPatrickSammy-Example.json
+++ b/Observation/Observation-CellularityPatrickSammy-Example.json
@@ -1,16 +1,10 @@
 {
   "resourceType": "Observation",
-  "id": "Observation-BlastPercentage-Example",
+  "id": "Observation-CellularityPatrickSammy-Example",
   "status": "final",
-  "code": {
-    "coding": [
-      {
-        "system": "http://snomed.info/sct",
-        "code": "1015521000000107",
-        "display": "Percentage blast cells (observable entity)"
-      }
-    ]
-  },
+"code": {
+  "text": "Cellularity"
+},
   "subject": {
     "reference": "Patient/Patient-PatrickSammy-Example",
     "identifier": {
@@ -30,11 +24,14 @@
       }
     }
   },
-  "valueQuantity": {
-    "value": 25,
-    "unit": "%",
-    "system": "http://unitsofmeasure.org",
-    "code": "%"
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+        "code": "H",
+        "display": "High"
+      }
+    ]
   },
   "effectiveDateTime": "2023-08-29"
 }


### PR DESCRIPTION
 - Create Observation-CellularityPatrickSammy-Example
- This example is needed to enable us capture cellularity under valueCodeableConcept. It was extracted from **Observation-BlastPercentage-Example.** So, Blast percentage and Cellularity are now captured with separate Observation resources.