### PR TITLE
Feature-IOPS-3020-WGS-Test-Order-Form-CancerSolidTumour

### DIFF
--- a/BodyStructure/BodyStructure-BodySiteLocationAbdomen-Example.json
+++ b/BodyStructure/BodyStructure-BodySiteLocationAbdomen-Example.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "BodyStructure",
+  "id": "BodyStructure-BodySiteLocationAbdomen-Example",
+  "morphology": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "369755005",
+        "display": "Multiple tumors (qualifier value)"
+      }
+    ]
+  },
+  "location": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "818983003",
+        "display": "Structure of abdominopelvic cavity and/or content of abdominopelvic cavity and/or anterior abdominal wall (body structure)"
+      }
+    ]
+  },
+  "patient": {
+    "reference": "Patient-DemeizaSeo-Example",
+    "identifier": {
+      "system": "https://fhir.nhs.uk/Id/nhs-number",
+      "value": "9449306559"
+    }
+  }
+}

--- a/Observation/Observation-PercentageMalignantNuclei-Example.json
+++ b/Observation/Observation-PercentageMalignantNuclei-Example.json
@@ -37,5 +37,5 @@
     "system": "http://unitsofmeasure.org",
     "code": "%"
   },
-  "effectiveDateTime": "2023-08-29"
+  "effectiveDateTime": "2023-08-09"
 }

--- a/Observation/Observation-PercentageMalignantNuclei-Example.json
+++ b/Observation/Observation-PercentageMalignantNuclei-Example.json
@@ -1,0 +1,41 @@
+{
+  "resourceType": "Observation",
+  "id": "Observation-PercentageMalignantNuclei-Example",
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1255076007",
+        "display": "Percent of cell nuclei positive for proliferation marker protein Ki-67 in primary malignant neoplasm of stomach by immunohistochemistry (observable entity)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/Patient-DemeizaSeo-Example",
+    "identifier": {
+      "system": "https://fhir.nhs.uk/Id/nhs-number",
+      "value": "9449306559"
+    }
+  },
+  "specimen": {
+    "reference":"Specimen/Specimen-SolidTumorDemeizaSeo-Example",
+    "identifier": {
+      "system": "https://fhir.add.nhs.uk/Id/specimenId",
+      "value": "RA257631",
+      "assigner": {
+        "identifier": {
+          "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+          "value": "696B0"
+        }
+      }
+    }
+  },
+  "valueQuantity": {
+    "value": 25,
+    "unit": "%",
+    "system": "http://unitsofmeasure.org",
+    "code": "%"
+  },
+  "effectiveDateTime": "2023-08-29"
+}

--- a/Observation/Observation-TumourTypeDemeizaSeo-Example.json
+++ b/Observation/Observation-TumourTypeDemeizaSeo-Example.json
@@ -1,0 +1,28 @@
+{
+  "resourceType": "Observation",
+  "id": "Observation-TumourTypeDemeizaSeo-Example",
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "116061001",
+        "display": "Solid pseudopapillary carcinoma (morphologic abnormality)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/Patient-DemeizaSeo-Example",
+    "identifier": {
+      "system": "https://fhir.nhs.uk/Id/nhs-number",
+      "value": "9449306559"
+    }
+  },
+  "specimen": {
+    "identifier": {
+      "system": "https://fhir.add.nhs.uk/Id/specimenId",
+      "value": "RA257631"
+    }
+  },
+  "effectiveDateTime": "2023-11-01T11:00:00Z"
+}

--- a/Observation/Observation-TumourTypeDemeizaSeo-Example.json
+++ b/Observation/Observation-TumourTypeDemeizaSeo-Example.json
@@ -24,5 +24,5 @@
       "value": "RA257631"
     }
   },
-  "effectiveDateTime": "2023-11-01T11:00:00Z"
+  "effectiveDateTime": "2023-09-08T11:00:00Z"
 }

--- a/ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example.json
+++ b/ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example.json
@@ -48,8 +48,8 @@
     "coding": [
       {
         "system": "https://fhir.nhs.uk/CodeSystem/England-GenomicTestDirectory",
-        "code": "M219.1",
-        "display": "Multi Target NGS Panel Small Variant"
+        "code": "M233.1",
+        "display": "WGS Germline and Tumour"
       }
     ]
   },

--- a/ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example.json
+++ b/ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example.json
@@ -30,6 +30,11 @@
           "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-GenomeSequencingCategory",
           "code": "cancer-wgs",
           "display": "Cancer - WGS"
+        },
+        {
+          "system": "https://fhir.nhs.uk/CodeSystem/reasonfortesting-genomics",
+          "code": "diagnostic",
+          "display": "Diagnostic"
         }
       ]
     }

--- a/ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example.json
+++ b/ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example.json
@@ -30,7 +30,11 @@
           "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-GenomeSequencingCategory",
           "code": "cancer-wgs",
           "display": "Cancer - WGS"
-        },
+        }
+      ]
+    },
+    {
+      "coding": [
         {
           "system": "https://fhir.nhs.uk/CodeSystem/reasonfortesting-genomics",
           "code": "diagnostic",

--- a/ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example.json
+++ b/ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example.json
@@ -76,21 +76,15 @@
     }
   ],
   "supportingInfo": [
-   
-   
     {
       "reference": "Observation/Observation-TumorType-Example"
     },
-   
     {
       "reference": "Observation/Observation-PercentageMalignantNuclei-Example"
     },
     {
-      "reference": "BodyStructure/BodyStructure-BodySiteLocationAbdomen-Example"
-    },
-      {
-        "reference": "Consent/Consent-RoDToFollow-Example"
-      }
+      "reference": "Consent/Consent-RoDToFollow-Example"
+    }
   ],
   "specimen": [
     {

--- a/ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example.json
+++ b/ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example.json
@@ -1,0 +1,108 @@
+{
+  "resourceType": "ServiceRequest",
+  "id": "ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example",
+  "extension": [
+    {
+      "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-Coverage",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-FundingCategory",
+            "code": "nhs-england",
+            "display": "NHS England"
+          }
+        ]
+      }
+    },
+    {
+      "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AdditionalContact",
+      "valueReference": {
+        "reference": "PractitionerRole/PractitionerRole-AnnaLaneKingstonPathology-Example"
+      }
+    }
+  ],
+  "status": "active",
+  "intent": "order",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-GenomeSequencingCategory",
+          "code": "cancer-wgs",
+          "display": "Cancer - WGS"
+        }
+      ]
+    }
+  ],
+  "priority": "routine",
+  "code": {
+    "coding": [
+      {
+        "system": "https://fhir.nhs.uk/CodeSystem/England-GenomicTestDirectory",
+        "code": "M219.1",
+        "display": "Multi Target NGS Panel Small Variant"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/Patient-DemeizaSeo-Example",
+    "identifier": {
+      "system": "https://fhir.nhs.uk/Id/nhs-number",
+      "value": "9449306559"
+    }
+  },
+  "authoredOn": "2023-09-08",
+  "requester": {
+    "reference": "PractitionerRole/PractitionerRole-HazelSmithKingstonPathology-Example"
+  },
+  "reasonCode": [
+    {
+      "coding": [
+        {
+          "system": "https://fhir.nhs.uk/CodeSystem/reasonfortesting-genomics",
+          "code": "diagnostic",
+          "display": "Diagnostic"
+        }
+      ]
+    }
+  ],
+  "performer": [
+    {
+      "identifier": {
+        "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+        "value": "RJZ"
+      },
+      "display": "KING'S COLLEGE HOSPITAL NHS FOUNDATION TRUST"
+    }
+  ],
+  "supportingInfo": [
+   
+   
+    {
+      "reference": "Observation/Observation-TumorType-Example"
+    },
+   
+    {
+      "reference": "Observation/Observation-PercentageMalignantNuclei-Example"
+    },
+    {
+      "reference": "BodyStructure/BodyStructure-BodySiteLocationAbdomen-Example"
+    },
+      {
+        "reference": "Consent/Consent-RoDToFollow-Example"
+      }
+  ],
+  "specimen": [
+    {
+      "reference": "Specimen/Specimen-SolidTumorDemeizaSeo-Example"
+    }
+  ],
+  "note": [
+    {
+      "text": "Relevant Family History"
+    },
+    {
+      "text": "Other Additional Information"
+    }
+  ]
+}

--- a/Specimen/Specimen-SolidTumorDemeizaSeo-Example.json
+++ b/Specimen/Specimen-SolidTumorDemeizaSeo-Example.json
@@ -1,0 +1,78 @@
+{
+  "resourceType": "Specimen",
+  "id": "Specimen-SolidTumorDemeizaSeo-Example",
+  "extension": [
+    {
+      "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-SampleCategory",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-SampleCategory",
+            "code": "tumour",
+            "display": "Tumour"
+          }
+        ],
+        "text": "Solid Tumour"
+      }
+    }
+  ],
+  "identifier": [
+    {
+      "system": "https://fhir.add.nhs.uk/Id/specimenId",
+      "value": "RA257631"
+    }
+  ],
+  "status": "available",
+  "type": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "364611000000101",
+        "display": "Tissue resection sample"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/Patient-DemeizaSeo-Example",
+    "identifier": {
+      "system": "https://fhir.nhs.uk/Id/nhs-number",
+      "value": "9449306559"
+    }
+  },
+  "collection": {
+    "collector": {
+      "identifier": {
+        "system": "https://fhir.nhs.uk/Id/sds-user-id",
+        "value": "9999999998"
+      },
+      "display": "ClinicalScientist-John Taylor"
+    },
+    "collectedDateTime": "2023-09-09T11:00:00Z",
+    "bodySite": {
+      "extension": [
+        {
+          "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-BodySiteReference",
+          "valueReference": {
+            "reference": "BodyStructure/BodyStructure-BodySiteLocationAbdomen-Example"
+          }
+        }
+      ]
+    }
+  },
+  "condition": [
+    {
+      "coding": [
+        {
+          "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-BiopsyState",
+          "code": "fresh-frozen",
+          "display": "Fresh Frozen"
+        }
+      ]
+    }
+  ],
+  "request": [
+    {
+      "reference": "ServiceRequest/ServiceRequest-WGS"
+    }
+  ]
+}

--- a/Specimen/Specimen-SolidTumorDemeizaSeo-Example.json
+++ b/Specimen/Specimen-SolidTumorDemeizaSeo-Example.json
@@ -8,8 +8,8 @@
         "coding": [
           {
             "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-SampleCategory",
-            "code": "tumour",
-            "display": "Tumour"
+            "code": "solid-tumour",
+            "display": "Solid Tumour"
           }
         ],
         "text": "Solid Tumour"

--- a/Specimen/Specimen-SolidTumorDemeizaSeo-Example.json
+++ b/Specimen/Specimen-SolidTumorDemeizaSeo-Example.json
@@ -11,8 +11,7 @@
             "code": "solid-tumour",
             "display": "Solid Tumour"
           }
-        ],
-        "text": "Solid Tumour"
+        ]
       }
     }
   ],

--- a/Specimen/Specimen-SolidTumorDemeizaSeo-Example.json
+++ b/Specimen/Specimen-SolidTumorDemeizaSeo-Example.json
@@ -62,9 +62,9 @@
     {
       "coding": [
         {
-          "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-BiopsyState",
-          "code": "fresh-frozen",
-          "display": "Fresh Frozen"
+          "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-PrimarySampleState",
+          "code": "fresh",
+          "display": "Fresh"
         }
       ]
     }

--- a/Specimen/Specimen-SolidTumorDemeizaSeo-Example.json
+++ b/Specimen/Specimen-SolidTumorDemeizaSeo-Example.json
@@ -72,7 +72,7 @@
   ],
   "request": [
     {
-      "reference": "ServiceRequest/ServiceRequest-WGS"
+      "reference": "ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example"
     }
   ]
 }

--- a/Task/Task-WGSCancerTestOrder-SolidTumour-Example.json
+++ b/Task/Task-WGSCancerTestOrder-SolidTumour-Example.json
@@ -1,0 +1,30 @@
+{
+  "resourceType": "Task",
+  "id": "Task-WGSCancerTestOrder-SolidTumor-Example",
+  "status": "requested",
+  "intent": "order",
+  "priority": "routine",
+  "code": { 
+    "coding": [
+      { 
+        "system": "https://fhir.nhs.uk/CodeSystem/task-code-genomics", 
+        "code": "process-genomic-test-request", 
+        "display": "Process Genomic Test Request"
+      }
+    ]
+  },
+  "focus": {
+    "reference": "ServiceRequest/ServiceRequest-WGSTestOrderForm-CancerSolidTumor-Example"
+  },
+  "for": {
+    "reference": "Patient/Patient-DemeizaSeo-Example",
+    "identifier": {
+      "system": "https://fhir.nhs.uk/Id/nhs-number",
+      "value": "9449306559"
+    }
+  },
+  "authoredOn": "2023-09-09",
+  "requester": {
+    "reference": "PractitionerRole/PractitionerRole-HazelSmithRenal-Example"
+  }
+}

--- a/Task/Task-WGSCancerTestOrder-SolidTumour-Example.json
+++ b/Task/Task-WGSCancerTestOrder-SolidTumour-Example.json
@@ -25,6 +25,6 @@
   },
   "authoredOn": "2023-09-09",
   "requester": {
-    "reference": "PractitionerRole/PractitionerRole-HazelSmithRenal-Example"
+    "reference": "PractitionerRole/PractitionerRole-HazelSmithKingstonPathology-Example"
   }
 }


### PR DESCRIPTION
This PR relates to WGS-Cancer-Solid Tumour. A separate PR will be raised for WGS-Cancer-HeamOnc with Sample as BloodEDTA so that we can represent the condition: If BM/PB provide volume and nucleated cell count

However, this [wireframe](https://mft.nhs.uk/app/uploads/2021/06/Whole-Genome-Sequencing-WGS-Test-Request-cancer.pdf) which seems to be what the GU adapted to produce [theirs](https://4r1u14.axshare.com/?id=8k29q1&p=wgs_cancer_test_order&c=1) has been followed to define tumour requirements.