### PR TITLE
Fix snomed terms

### DIFF
--- a/BodyStructure/BodyStructure-BodySiteLocationAbdomen-Example.json
+++ b/BodyStructure/BodyStructure-BodySiteLocationAbdomen-Example.json
@@ -6,7 +6,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "369755005",
-        "display": "Multiple tumors (qualifier value)"
+        "display": "Multiple tumors"
       }
     ]
   },
@@ -15,7 +15,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "818983003",
-        "display": "Structure of abdominopelvic cavity and/or content of abdominopelvic cavity and/or anterior abdominal wall (body structure)"
+        "display": "Structure of abdominopelvic cavity and/or content of abdominopelvic cavity and/or anterior abdominal wall"
       }
     ]
   },

--- a/BodyStructure/BodyStructure-BodySiteLocationLungs-Example.json
+++ b/BodyStructure/BodyStructure-BodySiteLocationLungs-Example.json
@@ -6,7 +6,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "369755005",
-        "display": "Multiple tumors (qualifier value)"
+        "display": "Multiple tumors"
       }
     ]
   },
@@ -15,7 +15,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "39607008",
-        "display": "Lung structure (body structure)"
+        "display": "Lung structure"
       }
     ]
   },

--- a/BodyStructure/BodyStructure-SpecimenBodySiteLocation-Example.json
+++ b/BodyStructure/BodyStructure-SpecimenBodySiteLocation-Example.json
@@ -6,7 +6,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "369755005",
-        "display": "Multiple tumors (qualifier value)"
+        "display": "Multiple tumors"
       }
     ]
   },
@@ -15,7 +15,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "76752008",
-        "display": "Breast structure (body structure)"
+        "display": "Breast structure"
       }
     ]
   },

--- a/Bundle/Bundle-NonWGSTestOrderForm-CancerSolidTumor-Example.json
+++ b/Bundle/Bundle-NonWGSTestOrderForm-CancerSolidTumor-Example.json
@@ -317,7 +317,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "128462008",
-              "display": "Metastatic malignant neoplasm (disorder)"
+              "display": "Metastatic malignant neoplasm"
             }
           ]
         },
@@ -347,7 +347,7 @@
                 {
                   "system": "http://snomed.info/sct",
                   "code": "369755005",
-                  "display": "Multiple tumors (qualifier value)"
+                  "display": "Multiple tumors"
                 }
               ]
             },
@@ -372,7 +372,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "6574001",
-              "display": "Necrosis (morphologic abnormality)"
+              "display": "Necrosis"
             }
           ]
         },

--- a/Bundle/Bundle-NonWGSTestOrderForm-Example.json
+++ b/Bundle/Bundle-NonWGSTestOrderForm-Example.json
@@ -314,7 +314,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "60001007",
-              "display": "Not pregnant (finding)"
+              "display": "Not pregnant"
             }
           ]
         },
@@ -389,7 +389,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "160475008",
-              "display": "Family history: Consanguinity (situation)"
+              "display": "Family history: Consanguinity"
             }
           ]
         },
@@ -419,7 +419,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "416128008",
-              "display": "No history of procedure (situation)"
+              "display": "No history of procedure"
             }
           ]
         },
@@ -428,7 +428,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "263903005",
-              "display": "Transplant (qualifier value)"
+              "display": "Transplant"
             }
           ]
         },
@@ -457,7 +457,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "416128008",
-              "display": "No history of procedure (situation)"
+              "display": "No history of procedure"
             }
           ]
         },
@@ -466,7 +466,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "303955003",
-              "display": "Transfusion - action (qualifier value)"
+              "display": "Transfusion - action"
             }
           ]
         },
@@ -532,8 +532,8 @@
           "coding": [
             {
               "system": "http://snomed.info/sct",
-              "code": "445295009",
-              "display": "Blood specimen with EDTA"
+              "code": "119297000",
+              "display": "Blood specimen"
             }
           ]
         },

--- a/Bundle/Bundle-NonWGSTestOrderForm-FetalScenario-Example.json
+++ b/Bundle/Bundle-NonWGSTestOrderForm-FetalScenario-Example.json
@@ -432,7 +432,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "161743003",
-              "display": "Past pregnancy history of stillbirth (situation)"
+              "display": "Past pregnancy history of stillbirth"
             }
           ],
           "text": "Is the testing for a fetal loss from 24+0 or more weeks of gestation?"
@@ -534,7 +534,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "160475008",
-              "display": "Family history: Consanguinity (situation)"
+              "display": "Family history: Consanguinity"
             }
           ]
         },
@@ -572,7 +572,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "416128008",
-              "display": "No history of procedure (situation)"
+              "display": "No history of procedure"
             }
           ]
         },
@@ -581,7 +581,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "263903005",
-              "display": "Transplant (qualifier value)"
+              "display": "Transplant"
             }
           ]
         },
@@ -736,8 +736,8 @@
           "coding": [
             {
               "system": "http://snomed.info/sct",
-              "code": "445295009",
-              "display": "Blood specimen with EDTA"
+              "code": "119297000",
+              "display": "Blood specimen"
             }
           ]
         },

--- a/Bundle/Bundle-NonWGSTestOrderForm-Reanalysis-Example.json
+++ b/Bundle/Bundle-NonWGSTestOrderForm-Reanalysis-Example.json
@@ -341,7 +341,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "60001007",
-              "display": "Not pregnant (finding)"
+              "display": "Not pregnant"
             }
           ]
         },
@@ -416,7 +416,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "160475008",
-              "display": "Family history: Consanguinity (situation)"
+              "display": "Family history: Consanguinity"
             }
           ]
         },
@@ -446,7 +446,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "416128008",
-              "display": "No history of procedure (situation)"
+              "display": "No history of procedure"
             }
           ]
         },
@@ -455,7 +455,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "445715009",
-              "display": "Blood and marrow transplantation (qualifier value)"
+              "display": "Blood and marrow transplantation"
             }
           ]
         },
@@ -484,7 +484,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "416128008",
-              "display": "No history of procedure (situation)"
+              "display": "No history of procedure"
             }
           ]
         },
@@ -493,7 +493,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "303955003",
-              "display": "Transfusion - action (qualifier value)"
+              "display": "Transfusion - action"
             }
           ]
         },

--- a/Bundle/Bundle-Searchset-Example.json
+++ b/Bundle/Bundle-Searchset-Example.json
@@ -34,8 +34,8 @@
                     "coding": [
                         {
                             "system": "http://snomed.info/sct",
-                            "code": "445295009",
-                            "display": "Blood specimen with EDTA"
+                            "code": "119297000",
+                            "display": "Blood specimen"
                         }
                     ]
                 },

--- a/Bundle/Bundle-WGSTestOrderForm-Example.json
+++ b/Bundle/Bundle-WGSTestOrderForm-Example.json
@@ -323,7 +323,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "60001007",
-              "display": "Not pregnant (finding)"
+              "display": "Not pregnant"
             }
           ]
         },
@@ -398,7 +398,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "160475008",
-              "display": "Family history: Consanguinity (situation)"
+              "display": "Family history: Consanguinity"
             }
           ]
         },
@@ -428,7 +428,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "416128008",
-              "display": "No history of procedure (situation)"
+              "display": "No history of procedure"
             }
           ]
         },
@@ -437,7 +437,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "445715009",
-              "display": "Blood and marrow transplantation (qualifier value)"
+              "display": "Blood and marrow transplantation"
             }
           ]
         },
@@ -466,7 +466,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "416128008",
-              "display": "No history of procedure (situation)"
+              "display": "No history of procedure"
             }
           ]
         },
@@ -475,7 +475,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "303955003",
-              "display": "Transfusion - action (qualifier value)"
+              "display": "Transfusion - action"
             }
           ]
         },
@@ -664,8 +664,8 @@
           "coding": [
             {
               "system": "http://snomed.info/sct",
-              "code": "445295009",
-              "display": "Blood specimen with EDTA"
+              "code": "119297000",
+              "display": "Blood specimen"
             }
           ]
         },

--- a/Bundle/UKCore-Bundle-MichaelJonesRequest-Example_v3_message.json
+++ b/Bundle/UKCore-Bundle-MichaelJonesRequest-Example_v3_message.json
@@ -641,10 +641,10 @@
 				"type": {
 					"coding": [
 						{
-							"system": "http://snomed.info/sct",
-							"code": "87612001",
-							"display": "Blood (substance)"
-						}
+              "system": "http://snomed.info/sct",
+              "code": "119297000",
+              "display": "Blood specimen"
+            }
 					]
 				},
 				"subject": {
@@ -680,7 +680,7 @@
 							{
 								"system": "http://snomed.info/sct",
 								"code": "14975008",
-								"display": "Forearm structure (body structure)"
+								"display": "Forearm structure"
 							}
 						]
 					}
@@ -711,7 +711,7 @@
 								{
 									"system": "http://snomed.info/sct",
 									"code": "706067003",
-									"display": "Blood collection/transfer device (physical object)"
+									"display": "Blood collection/transfer device"
 								}
 							]
 						},

--- a/Bundle/UKCore-Bundle-MichaelJonesSpecimen-Example.json
+++ b/Bundle/UKCore-Bundle-MichaelJonesSpecimen-Example.json
@@ -24,8 +24,8 @@
 					"coding": [
 						{ 
 							"system": "http://snomed.info/sct", 
-							"code": "87612001", 
-							"display": "Blood (substance)"
+							"code": "119297000", 
+							"display": "Blood specimen"
 						}
 					]
 				},
@@ -62,7 +62,7 @@
 							{
 								"system": "http://snomed.info/sct", 
 								"code": "14975008", 
-								"display": "Forearm structure (body structure)"
+								"display": "Forearm structure"
 							}
 						]
 					}
@@ -93,7 +93,7 @@
 								{
 									"system": "http://snomed.info/sct", 
 									"code": "706067003", 
-									"display": "Blood collection/transfer device (physical object)"
+									"display": "Blood collection/transfer device"
 								}
 							]
 						},

--- a/ConceptMap/ConceptMap-Genomics-condition-laterality-of-hearingloss.json
+++ b/ConceptMap/ConceptMap-Genomics-condition-laterality-of-hearingloss.json
@@ -34,7 +34,7 @@
           "target": [
             {
               "code": "95820000",
-              "display": "Bilateral hearing loss (disorder)",
+              "display": "Bilateral hearing loss",
               "equivalence": "equivalent"
             }
           ]
@@ -45,7 +45,7 @@
           "target": [
             {
               "code": "473424007",
-              "display": "Hearing loss of left ear (disorder)",
+              "display": "Hearing loss of left ear",
               "equivalence": "equivalent"
             }
           ]
@@ -56,7 +56,7 @@
           "target": [
             {
               "code": "473423001",
-              "display": "Hearing loss of right ear (disorder)",
+              "display": "Hearing loss of right ear",
               "equivalence": "equivalent"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-condition-liquidtumourtype.json
+++ b/ConceptMap/ConceptMap-Genomics-condition-liquidtumourtype.json
@@ -33,7 +33,7 @@
           "target": [
             {
               "code": "91861009",
-              "display": "Acute myeloid leukemia (disorder)",
+              "display": "Acute myeloid leukemia",
               "equivalence": "equivalent"
             }
           ]
@@ -44,7 +44,7 @@
           "target": [
             {
               "code": "91857003",
-              "display": "Acute lymphoid leukemia, disease (disorder)",
+              "display": "Acute lymphoid leukemia, disease",
               "equivalence": "equivalent"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-condition-pancreatictumourtype.json
+++ b/ConceptMap/ConceptMap-Genomics-condition-pancreatictumourtype.json
@@ -33,7 +33,7 @@
           "target": [
             {
               "code": "20955008",
-              "display": "Insulinoma, malignant (morphologic abnormality)",
+              "display": "Insulinoma, malignant",
               "equivalence": "equivalent"
             }
           ]
@@ -44,7 +44,7 @@
           "target": [
             {
               "code": "19756007",
-              "display": "Gastrinoma, malignant (morphologic abnormality)",
+              "display": "Gastrinoma, malignant",
               "equivalence": "equivalent"
             }
           ]
@@ -55,7 +55,7 @@
           "target": [
             {
               "code": "66515009",
-              "display": "Glucagonoma, malignant (morphologic abnormality)",
+              "display": "Glucagonoma, malignant",
               "equivalence": "equivalent"
             }
           ]
@@ -66,7 +66,7 @@
           "target": [
             {
               "code": "31131002",
-              "display": "Vipoma, malignant (morphologic abnormality)",
+              "display": "Vipoma, malignant",
               "equivalence": "equivalent"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-condition-pituitarytumourtype.json
+++ b/ConceptMap/ConceptMap-Genomics-condition-pituitarytumourtype.json
@@ -33,7 +33,7 @@
           "target": [
             {
               "code": "254957009",
-              "display": "Somatotroph adenoma (disorder)",
+              "display": "Somatotroph adenoma",
               "equivalence": "equivalent"
             }
           ]
@@ -44,7 +44,7 @@
           "target": [
             {
               "code": "134209002",
-              "display": "Prolactinoma (disorder)",
+              "display": "Prolactinoma",
               "equivalence": "equivalent"
             }
           ]
@@ -55,7 +55,7 @@
           "target": [
             {
               "code": "254962005",
-              "display": "Functionless pituitary adenoma (disorder)",
+              "display": "Functionless pituitary adenoma",
               "equivalence": "equivalent"
             }
           ]
@@ -66,7 +66,7 @@
           "target": [
             {
               "code": "190502001",
-              "display": "Pituitary-dependent Cushing's disease (disorder)",
+              "display": "Pituitary-dependent Cushing's disease",
               "equivalence": "equivalent"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-condition-solidtumourtype.json
+++ b/ConceptMap/ConceptMap-Genomics-condition-solidtumourtype.json
@@ -2,11 +2,11 @@
   "resourceType": "ConceptMap",
   "id": "genomics-condition-solidtumourtype",
   "url": "https://fhir.nhs.uk/ConceptMap/genomics-condition-solidtumourtype",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "name": "GenomicsConditionSolidTumourType",
   "title": "Genomics Condition Solid Tumour Type",
   "status": "draft",
-  "date": "2024-06-11T00:00:00.000Z",
+  "date": "2025-05-19T00:00:00.000Z",
   "publisher": "NHS England",
   "contact": [
     {
@@ -32,8 +32,8 @@
           "display": "SOLID",
           "target": [
             {
-              "code": "35702001",
-              "display": "Solid (qualifier value)",
+              "code": "369757002",
+              "display": "Solid tumor configuration",
               "equivalence": "equivalent"
             }
           ]
@@ -43,8 +43,8 @@
           "display": "PRIMARY",
           "target": [
             {
-              "code": "63161005",
-              "display": "Principal (qualifier value)",
+              "code": "372087000",
+              "display": "Primary malignant neoplasm",
               "equivalence": "equivalent"
             }
           ]
@@ -54,8 +54,8 @@
           "display": "METASTATIC",
           "target": [
             {
-              "code": "1505291000004100",
-              "display": "Discontinuous metastatic spread (qualifier value)",
+              "code": "14799000",
+              "display": "Neoplasm, metastatic",
               "equivalence": "equivalent"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-fetal-maternal-screening-genotype.json
+++ b/ConceptMap/ConceptMap-Genomics-fetal-maternal-screening-genotype.json
@@ -34,7 +34,7 @@
           "target": [
             {
               "code": "234389001",
-              "display": "Alpha-beta thalassemia (disorder)",
+              "display": "Alpha-beta thalassemia",
               "equivalence": "equivalent"
             }
           ]
@@ -45,7 +45,7 @@
           "target": [
             {
               "code": "76050008",
-              "display": "Hemoglobin C trait (disorder)",
+              "display": "Hemoglobin C trait",
               "equivalence": "equivalent"
             }
           ]
@@ -67,7 +67,7 @@
           "target": [
             {
               "code": "35434009",
-              "display": "Sickle cell-hemoglobin C disease (disorder)",
+              "display": "Sickle cell-hemoglobin C disease",
               "equivalence": "equivalent"
             }
           ]
@@ -78,7 +78,7 @@
           "target": [
             {
               "code": "127040003",
-              "display": "Sickle cell-hemoglobin SS disease (disorder)",
+              "display": "Sickle cell-hemoglobin SS disease",
               "equivalence": "equivalent"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-procedure-transfusiontype.json
+++ b/ConceptMap/ConceptMap-Genomics-procedure-transfusiontype.json
@@ -34,7 +34,7 @@
           "target": [
             {
               "code": "71493000",
-              "display": "Transfusion of packed red blood cells (procedure)",
+              "display": "Transfusion of packed red blood cells",
               "equivalence": "equivalent"
             }
           ]
@@ -45,7 +45,7 @@
           "target": [
             {
               "code": "13569004",
-              "display": "Transfusion of plasma (procedure)",
+              "display": "Transfusion of plasma",
               "equivalence": "equivalent"
             }
           ]
@@ -56,7 +56,7 @@
           "target": [
             {
               "code": "12719002",
-              "display": "Platelet transfusion (procedure)",
+              "display": "Platelet transfusion",
               "equivalence": "equivalent"
             }
           ]
@@ -67,7 +67,7 @@
           "target": [
             {
               "code": "5447007",
-              "display": "Transfusion (procedure)",
+              "display": "Transfusion",
               "equivalence": "specializes"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-risk-reason-for-specimen-specialhandling.json
+++ b/ConceptMap/ConceptMap-Genomics-risk-reason-for-specimen-specialhandling.json
@@ -34,7 +34,7 @@
           "target": [
             {
               "code": "409498004",
-              "display": "Anthrax (disorder)",
+              "display": "Anthrax",
               "equivalence": "equivalent"
             }
           ]
@@ -45,7 +45,7 @@
           "target": [
             {
               "code": "75702008",
-              "display": "Brucellosis (disorder)",
+              "display": "Brucellosis",
               "equivalence": "equivalent"
             }
           ]
@@ -56,7 +56,7 @@
           "target": [
             {
               "code": "127531000119106",
-              "display": "Infection caused by Escherichia coli O157 (disorder)",
+              "display": "Infection caused by Escherichia coli O157",
               "equivalence": "equivalent"
             }
           ]
@@ -67,7 +67,7 @@
           "target": [
             {
               "code": "111407006",
-              "display": "Hemolytic uremic syndrome (disorder)",
+              "display": "Hemolytic uremic syndrome",
               "equivalence": "equivalent"
             }
           ]
@@ -78,7 +78,7 @@
           "target": [
             {
               "code": "86406008",
-              "display": "Human immunodeficiency virus infection (disorder)",
+              "display": "Human immunodeficiency virus infection",
               "equivalence": "equivalent"
             }
           ]
@@ -89,7 +89,7 @@
           "target": [
             {
               "code": "228388006",
-              "display": "Intravenous drug user (finding)",
+              "display": "Intravenous drug user",
               "equivalence": "equivalent"
             }
           ]
@@ -100,7 +100,7 @@
           "target": [
             {
               "code": "792004",
-              "display": "Jakob-Creutzfeldt disease (disorder)",
+              "display": "Jakob-Creutzfeldt disease",
               "equivalence": "equivalent"
             }
           ]
@@ -111,7 +111,7 @@
           "target": [
             {
               "code": "428111003",
-              "display": "Melioidosis (disorder)",
+              "display": "Melioidosis",
               "equivalence": "equivalent"
             }
           ]
@@ -122,7 +122,7 @@
           "target": [
             {
               "code": "56717001",
-              "display": "Tuberculosis (disorder)",
+              "display": "Tuberculosis",
               "equivalence": "equivalent"
             }
           ]
@@ -133,7 +133,7 @@
           "target": [
             {
               "code": "4834000",
-              "display": "Typhoid fever (disorder)",
+              "display": "Typhoid fever",
               "equivalence": "equivalent"
             }
           ]
@@ -144,7 +144,7 @@
           "target": [
             {
               "code": "3738000",
-              "display": "Viral hepatitis (disorder)",
+              "display": "Viral hepatitis",
               "equivalence": "equivalent"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-specimen-final-sample.json
+++ b/ConceptMap/ConceptMap-Genomics-specimen-final-sample.json
@@ -33,7 +33,7 @@
           "target": [
             {
               "code": "258566005",
-              "display": "Deoxyribonucleic acid specimen (specimen)",
+              "display": "Deoxyribonucleic acid specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -44,7 +44,7 @@
           "target": [
             {
               "code": "441673008",
-              "display": "Ribonucleic acid specimen (specimen)",
+              "display": "Ribonucleic acid specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -55,7 +55,7 @@
           "target": [
             {
               "code": "70016006",
-              "display": "Complementary deoxyribonucleic acid (substance)",
+              "display": "Complementary deoxyribonucleic acid",
               "equivalence": "equivalent"
             }
           ]
@@ -76,7 +76,7 @@
           "target": [
             {
               "code": "70016006",
-              "display": "Cell free deoxyribonucleic acid (substance)",
+              "display": "Cell free deoxyribonucleic acid",
               "equivalence": "equivalent"
             }
           ]
@@ -87,7 +87,7 @@
           "target": [
             {
               "code": "702451000",
-              "display": "Cultured cells (substance)",
+              "display": "Cultured cells",
               "equivalence": "equivalent"
             }
           ]
@@ -98,13 +98,13 @@
           "target": [
             {
               "code": "787150001",
-              "display": "Stained slide of tissue section (specimen)",
+              "display": "Stained slide of tissue section",
               "equivalence": "narrower",
               "comment": "An appropriate concept should be selected to indicate either stained or unstained."
             },
             {
               "code": "787149001",
-              "display": "Unstained slide of tissue section (specimen)",
+              "display": "Unstained slide of tissue section",
               "equivalence": "narrower",
               "comment": "An appropriate concept should be selected to indicate either stained or unstained."
             }
@@ -116,7 +116,7 @@
           "target": [
             {
               "code": "123038009",
-              "display": "Specimen (specimen)",
+              "display": "Specimen",
               "equivalence": "wider",
               "comment": "Any other suitable Specimen types not listed on this code. This should be provided by free text if no suitable SNOMED CT is found."
             }

--- a/ConceptMap/ConceptMap-Genomics-specimen-primarysample.json
+++ b/ConceptMap/ConceptMap-Genomics-specimen-primarysample.json
@@ -34,7 +34,7 @@
           "target": [
             {
               "code": "119373006",
-              "display": "Amniotic fluid specimen (specimen)",
+              "display": "Amniotic fluid specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -89,7 +89,7 @@
           "target": [
             {
               "code": "258450006",
-              "display": "Cerebrospinal fluid specimen (specimen)",
+              "display": "Cerebrospinal fluid specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -100,7 +100,7 @@
           "target": [
             {
               "code": "122556008",
-              "display": "Cord blood specimen (specimen)",
+              "display": "Cord blood specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -144,7 +144,7 @@
           "target": [
             {
               "code": "127462005",
-              "display": "Specimen from heart (specimen)",
+              "display": "Specimen from heart",
               "equivalence": "equivalent"
             }
           ]
@@ -155,7 +155,7 @@
           "target": [
             {
               "code": "127473003",
-              "display": "Specimen from kidney (specimen)",
+              "display": "Specimen from kidney",
               "equivalence": "equivalent"
             }
           ]
@@ -166,7 +166,7 @@
           "target": [
             {
               "code": "119383005",
-              "display": "Specimen from liver (specimen)",
+              "display": "Specimen from liver",
               "equivalence": "equivalent"
             }
           ]
@@ -188,7 +188,7 @@
           "target": [
             {
               "code": "123038009",
-              "display": "Specimen (specimen)",
+              "display": "Specimen",
               "equivalence": "wider",
               "comment": "Any other suitable descendant of 123038009|Specimen (specimen) not listed on this code. This should be provided by free text if no suitable SNOMED CT is found."
             }
@@ -200,7 +200,7 @@
           "target": [
             {
               "code": "122571007",
-              "display": "Pericardial fluid specimen (specimen)",
+              "display": "Pericardial fluid specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -211,7 +211,7 @@
           "target": [
             {
               "code": "430250001",
-              "display": "Specimen from peritoneum (specimen)",
+              "display": "Specimen from peritoneum",
               "equivalence": "equivalent"
             }
           ]
@@ -222,7 +222,7 @@
           "target": [
             {
               "code": "418564007",
-              "display": "Pleural fluid specimen (specimen)",
+              "display": "Pleural fluid specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -244,7 +244,7 @@
           "target": [
             {
               "code": "119342007",
-              "display": "Saliva specimen (specimen)",
+              "display": "Saliva specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -255,7 +255,7 @@
           "target": [
             {
               "code": "119331003",
-              "display": "Skeletal muscle specimen (specimen)",
+              "display": "Skeletal muscle specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -266,7 +266,7 @@
           "target": [
             {
               "code": "608969007",
-              "display": "Specimen from skin (specimen)",
+              "display": "Specimen from skin",
               "equivalence": "equivalent"
             }
           ]
@@ -277,7 +277,7 @@
           "target": [
             {
               "code": "433308004",
-              "display": "Specimen from spleen (specimen)",
+              "display": "Specimen from spleen",
               "equivalence": "equivalent"
             }
           ]
@@ -288,7 +288,7 @@
           "target": [
             {
               "code": "258435002",
-              "display": "Tumor tissue specimen (specimen)",
+              "display": "Tumor tissue specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -299,7 +299,7 @@
           "target": [
             {
               "code": "122575003",
-              "display": "Urine specimen (specimen)",
+              "display": "Urine specimen",
               "equivalence": "equivalent"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-specimen-samplepreparation.json
+++ b/ConceptMap/ConceptMap-Genomics-specimen-samplepreparation.json
@@ -34,7 +34,7 @@
           "target": [
             {
               "code": "798001000000102",
-              "display": "CD138 count (procedure)",
+              "display": "CD138 count",
               "equivalence": "equivalent"
             }
           ]
@@ -45,7 +45,7 @@
           "target": [
             {
               "code": "785421000000106",
-              "display": "CD15 count (procedure)",
+              "display": "CD15 count",
               "equivalence": "equivalent"
             }
           ]
@@ -56,7 +56,7 @@
           "target": [
             {
               "code": "408228002",
-              "display": "Absolute CD19 count (procedure)",
+              "display": "Absolute CD19 count",
               "equivalence": "equivalent"
             }
           ]
@@ -67,7 +67,7 @@
           "target": [
             {
               "code": "313447006",
-              "display": "Absolute CD3 count procedure (procedure)",
+              "display": "Absolute CD3 count procedure",
               "equivalence": "equivalent"
             }
           ]
@@ -78,7 +78,7 @@
           "target": [
             {
               "code": "313505009",
-              "display": "CD34 stem cell count procedure (procedure)",
+              "display": "CD34 stem cell count procedure",
               "equivalence": "equivalent"
             }
           ]
@@ -89,7 +89,7 @@
           "target": [
             {
               "code": "413790005",
-              "display": "CD5 count (procedure)",
+              "display": "CD5 count",
               "equivalence": "equivalent"
             }
           ]
@@ -111,7 +111,7 @@
           "target": [
             {
               "code": "787995009",
-              "display": "Microdissection of tissue specimen (procedure)",
+              "display": "Microdissection of tissue specimen",
               "equivalence": "equivalent"
             }
           ]
@@ -122,7 +122,7 @@
           "target": [
             {
               "code": "71388002",
-              "display": "Procedure (procedure)",
+              "display": "Procedure",
               "equivalence": "wider",
               "comment": "Any other suitable procedure that is an alternative to the concepts provided in this code. This should be provided by free text."
             }
@@ -134,7 +134,7 @@
           "target": [
             {
               "code": "407663004",
-              "display": "Percentage plasma cell count (procedure)",
+              "display": "Percentage plasma cell count",
               "equivalence": "equivalent"
             }
           ]
@@ -156,7 +156,7 @@
           "target": [
             {
               "code": "302560003",
-              "display": "Determination of percentage differential white blood cells (procedure)",
+              "display": "Determination of percentage differential white blood cells",
               "equivalence": "equivalent"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-specimen-tumourcellularity.json
+++ b/ConceptMap/ConceptMap-Genomics-specimen-tumourcellularity.json
@@ -34,7 +34,7 @@
           "target": [
             {
               "code": "75540009",
-              "display": "High (qualifier value)",
+              "display": "High",
               "equivalence": "equivalent"
             }
           ]
@@ -45,7 +45,7 @@
           "target": [
             {
               "code": "62482003",
-              "display": "Low (qualifier value)",
+              "display": "Low",
               "equivalence": "equivalent"
             }
           ]
@@ -56,7 +56,7 @@
           "target": [
             {
               "code": "255508009",
-              "display": "Medium (qualifier value)",
+              "display": "Medium",
               "equivalence": "equivalent"
             }
           ]
@@ -67,7 +67,7 @@
           "target": [
             {
               "code": "260360000",
-              "display": "Very high (qualifier value)",
+              "display": "Very high",
               "equivalence": "equivalent"
             }
           ]
@@ -78,7 +78,7 @@
           "target": [
             {
               "code": "260360000",
-              "display": "Very low (qualifier value)",
+              "display": "Very low",
               "equivalence": "equivalent"
             }
           ]

--- a/ConceptMap/ConceptMap-Genomics-typeof-transplantprocedure.json
+++ b/ConceptMap/ConceptMap-Genomics-typeof-transplantprocedure.json
@@ -33,7 +33,7 @@
           "target": [
             {
               "code": "232660006",
-              "display": "Bilateral sequential single lung transplant (procedure)",
+              "display": "Bilateral sequential single lung transplant",
               "equivalence": "equivalent"
             }
           ]
@@ -44,7 +44,7 @@
           "target": [
             {
               "code": "23719005",
-              "display": "Transplantation of bone marrow (procedure)",
+              "display": "Transplantation of bone marrow",
               "equivalence": "equivalent"
             }
           ]
@@ -55,7 +55,7 @@
           "target": [
             {
               "code": "70536003",
-              "display": "Transplant of kidney (procedure)",
+              "display": "Transplant of kidney",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided that this transplation procedure is for double kidney. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -67,7 +67,7 @@
           "target": [
             {
               "code": "232658009",
-              "display": "Double lung transplant (procedure)",
+              "display": "Double lung transplant",
               "equivalence": "equivalent"
             }
           ]
@@ -88,7 +88,7 @@
           "target": [
             {
               "code": "32413006",
-              "display": "Transplantation of heart (procedure)",
+              "display": "Transplantation of heart",
               "equivalence": "equivalent"
             }
           ]
@@ -99,13 +99,13 @@
           "target": [
             {
               "code": "32413006",
-              "display": "Transplantation of heart (procedure)",
+              "display": "Transplantation of heart",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that this transplantation procedure is for a combined heart and kidney transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "70536003",
-              "display": "Transplant of kidney (procedure)",
+              "display": "Transplant of kidney",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that this transplantation procedure is for combined heart and kidney procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -117,13 +117,13 @@
           "target": [
             {
               "code": "32413006",
-              "display": "Transplantation of heart (procedure)",
+              "display": "Transplantation of heart",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "18027006",
-              "display": "Transplantation of liver (procedure)",
+              "display": "Transplantation of liver",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -146,19 +146,19 @@
           "target": [
             {
               "code": "32413006",
-              "display": "Transplantation of heart (procedure)",
+              "display": "Transplantation of heart",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "88039007",
-              "display": "Transplant of lung (procedure)",
+              "display": "Transplant of lung",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "70536003",
-              "display": "Transplant of kidney (procedure)",
+              "display": "Transplant of kidney",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -170,19 +170,19 @@
           "target": [
             {
               "code": "32413006",
-              "display": "Transplantation of heart (procedure)",
+              "display": "Transplantation of heart",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "88039007",
-              "display": "Transplant of lung (procedure)",
+              "display": "Transplant of lung",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "18027006",
-              "display": "Transplantation of liver (procedure)",
+              "display": "Transplantation of liver",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -194,19 +194,19 @@
           "target": [
             {
               "code": "18027006",
-              "display": "Transplantation of liver (procedure)",
+              "display": "Transplantation of liver",
               "equivalence": "narrower",
               "comment": "A negative IF (Incompatible Factor) Blood test is a precondition to carrying out this combined procedure. The IF Blood test (250406009|Blood Incompatible(finding)) should be recorded in an observation resource. When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "56283009",
-              "display": "Transplantation of small intestine (procedure)",
+              "display": "Transplantation of small intestine",
               "equivalence": "narrower",
               "comment": "A negative IF (Incompatible Factor) Blood test is a precondition to carrying out this combined procedure. The IF Blood test (250406009|Blood Incompatible(finding)) should be recorded in an observation resource. When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "62438007",
-              "display": "Transplantation of pancreas (procedure)",
+              "display": "Transplantation of pancreas",
               "equivalence": "narrower",
               "comment": "A negative IF (Incompatible Factor) Blood test is a precondition to carrying out this combined procedure. The IF Blood test (250406009|Blood Incompatible(finding)) should be recorded in an observation resource. When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -218,7 +218,7 @@
           "target": [
             {
               "code": "18027006",
-              "display": "Transplantation of liver (procedure)",
+              "display": "Transplantation of liver",
               "equivalence": "equivalent",
               "comment": "A negative IF (Incompatible Factor) Blood test is a precondition to carrying out this procedure. The IF Blood test (250406009|Blood Incompatible(finding)) should be recorded in an observation resource.The procedures should be recorded in a separate Procedure resource."
             }
@@ -230,7 +230,7 @@
           "target": [
             {
               "code": "118158008",
-              "display": "Gastrointestinal tract transplantation (procedure)",
+              "display": "Gastrointestinal tract transplantation",
               "equivalence": "equivalent",
               "comment": "A negative IF (Incompatible Factor) Blood test is a precondition to carrying out this procedure. The IF Blood test (250406009|Blood Incompatible(finding)) should be recorded in an observation resource.The procedures should be recorded in a separate Procedure resource."
             }
@@ -242,7 +242,7 @@
           "target": [
             {
               "code": "70536003",
-              "display": "Transplant of kidney (procedure)",
+              "display": "Transplant of kidney",
               "equivalence": "equivalent"
             }
           ]
@@ -253,7 +253,7 @@
           "target": [
             {
               "code": "6471000179103",
-              "display": "Transplantation of kidney and pancreas (procedure)",
+              "display": "Transplantation of kidney and pancreas",
               "equivalence": "equivalent",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -265,19 +265,19 @@
           "target": [
             {
               "code": "70536003",
-              "display": "Transplant of kidney (procedure)",
+              "display": "Transplant of kidney",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "128531006",
-              "display": "Islet cell transplant (procedure)",
+              "display": "Islet cell transplant",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "62438007",
-              "display": "Transplantation of pancreas (procedure)",
+              "display": "Transplantation of pancreas",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -289,7 +289,7 @@
           "target": [
             {
               "code": "18027006",
-              "display": "Transplantation of liver (procedure)",
+              "display": "Transplantation of liver",
               "equivalence": "equivalent"
             }
           ]
@@ -300,13 +300,13 @@
           "target": [
             {
               "code": "18027006",
-              "display": "Transplantation of liver (procedure)",
+              "display": "Transplantation of liver",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "70536003",
-              "display": "Transplant of kidney (procedure)",
+              "display": "Transplant of kidney",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -318,13 +318,13 @@
           "target": [
             {
               "code": "18027006",
-              "display": "Transplantation of liver (procedure)",
+              "display": "Transplantation of liver",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "62438007",
-              "display": "Transplantation of pancreas (procedure)",
+              "display": "Transplantation of pancreas",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -336,19 +336,19 @@
           "target": [
             {
               "code": "18027006",
-              "display": "Transplantation of liver (procedure)",
+              "display": "Transplantation of liver",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "70536003",
-              "display": "Transplant of kidney (procedure)",
+              "display": "Transplant of kidney",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "62438007",
-              "display": "Transplantation of pancreas (procedure)",
+              "display": "Transplantation of pancreas",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -360,7 +360,7 @@
           "target": [
             {
               "code": "88039007",
-              "display": "Transplant of lung (procedure)",
+              "display": "Transplant of lung",
               "equivalence": "equivalent"
             }
           ]
@@ -371,13 +371,13 @@
           "target": [
             {
               "code": "88039007",
-              "display": "Transplant of lung (procedure)",
+              "display": "Transplant of lung",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "70536003",
-              "display": "Transplant of kidney (procedure)",
+              "display": "Transplant of kidney",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -389,19 +389,19 @@
           "target": [
             {
               "code": "88039007",
-              "display": "Transplant of lung (procedure)",
+              "display": "Transplant of lung",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "70536003",
-              "display": "Transplant of kidney (procedure)",
+              "display": "Transplant of kidney",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "18027006",
-              "display": "Transplantation of liver (procedure)",
+              "display": "Transplantation of liver",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -413,13 +413,13 @@
           "target": [
             {
               "code": "88039007",
-              "display": "Transplant of lung (procedure)",
+              "display": "Transplant of lung",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "18027006",
-              "display": "Transplantation of liver (procedure)",
+              "display": "Transplantation of liver",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -431,7 +431,7 @@
           "target": [
             {
               "code": "120095006",
-              "display": "Eye structure transplantation (procedure)",
+              "display": "Eye structure transplantation",
               "equivalence": "wider"
             }
           ]
@@ -442,7 +442,7 @@
           "target": [
             {
               "code": "62438007",
-              "display": "Transplantation of pancreas (procedure)",
+              "display": "Transplantation of pancreas",
               "equivalence": "equivalent"
             }
           ]
@@ -453,13 +453,13 @@
           "target": [
             {
               "code": "62438007",
-              "display": "Transplantation of pancreas (procedure)",
+              "display": "Transplantation of pancreas",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "62438007",
-              "display": "Transplantation of pancreas (procedure)",
+              "display": "Transplantation of pancreas",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -471,13 +471,13 @@
           "target": [
             {
               "code": "62438007",
-              "display": "Transplantation of pancreas (procedure)",
+              "display": "Transplantation of pancreas",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "128531006",
-              "display": "Islet cell transplant (procedure)",
+              "display": "Islet cell transplant",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -489,7 +489,7 @@
           "target": [
             {
               "code": "6471000179103",
-              "display": "Transplantation of kidney and pancreas (procedure)",
+              "display": "Transplantation of kidney and pancreas",
               "equivalence": "equivalent"
             }
           ]
@@ -500,19 +500,19 @@
           "target": [
             {
               "code": "62438007",
-              "display": "Transplantation of pancreas (procedure)",
+              "display": "Transplantation of pancreas",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "62438007",
-              "display": "Transplantation of pancreas (procedure)",
+              "display": "Transplantation of pancreas",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             },
             {
               "code": "70536003",
-              "display": "Transplant of kidney (procedure)",
+              "display": "Transplant of kidney",
               "equivalence": "narrower",
               "comment": "When this concept is used, further notes should be provided to state that it is a combined transplant procedure. Respective procedures should be recorded in a separate Procedure resource."
             }
@@ -524,7 +524,7 @@
           "target": [
             {
               "code": "429332008",
-              "display": "Transplantation of single lobe of lung (procedure)",
+              "display": "Transplantation of single lobe of lung",
               "equivalence": "equivalent"
             }
           ]
@@ -535,7 +535,7 @@
           "target": [
             {
               "code": "285581000000102",
-              "display": "Transplantation of stem cells (procedure)",
+              "display": "Transplantation of stem cells",
               "equivalence": "equivalent"
             }
           ]

--- a/Condition/Condition-AcuteMyeloidLeukaemia-Example.json
+++ b/Condition/Condition-AcuteMyeloidLeukaemia-Example.json
@@ -24,7 +24,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "1162928000",
-        "display": "Acute myeloid leukemia (morphologic abnormality)"
+        "display": "Acute myeloid leukemia"
       }
     ]
   },

--- a/DiagnosticReport/DiagnosticReport-GenomicVariantAssessment-Example.json
+++ b/DiagnosticReport/DiagnosticReport-GenomicVariantAssessment-Example.json
@@ -70,6 +70,11 @@
       {
         "system": "http://loinc.org",
         "code": "51969-4"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "1054161000000101",
+        "display": "Genetic report"
       }
     ]
   },
@@ -126,6 +131,15 @@
           "code": "LA6576-8",
           "display": "Positive"
         },
+        {
+          "system": "http://snomed.info/sct",
+          "code": "10828004",
+          "display": "Positive"
+        }
+      ]
+    },
+    {
+      "coding": [
         {
           "system": "http://snomed.info/sct",
           "code": "699866005",

--- a/DiagnosticReport/UKCore-DiagnosticReport-MichaelJonesReport-Example.json
+++ b/DiagnosticReport/UKCore-DiagnosticReport-MichaelJonesReport-Example.json
@@ -32,7 +32,7 @@
 			{ 
 				"system": "http://snomed.info/sct", 
 				"code": "4321000179101", 
-				"display": "Hematology report (record artifact)"
+				"display": "Hematology report"
 			}
 		]
 	},
@@ -64,7 +64,7 @@
 				{ 
 					"system": "http://snomed.info/sct", 
 					"code": "738542003", 
-					"display": "Dihydropyrimidine dehydrogenase poor metabolizer (finding)"
+					"display": "Dihydropyrimidine dehydrogenase poor metabolizer"
 				}
 			]
 		}

--- a/FamilyMemberHistory/FamilyMemberHistory-MildCognitiveDisorder-Example.json
+++ b/FamilyMemberHistory/FamilyMemberHistory-MildCognitiveDisorder-Example.json
@@ -25,7 +25,7 @@
           {
             "system": "http://snomed.info/sct",
             "code": "386805003",
-            "display": "Mild neurocognitive disorder (disorder)"
+            "display": "Mild neurocognitive disorder"
           }
         ]
       }

--- a/Observation/Observation-BlastPercentage-Example.json
+++ b/Observation/Observation-BlastPercentage-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "1015521000000107",
-        "display": "Percentage blast cells (observable entity)"
+        "display": "Percentage blast cells"
       }
     ]
   },

--- a/Observation/Observation-BlastPercentageWGSSample-Example.json
+++ b/Observation/Observation-BlastPercentageWGSSample-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "1015521000000107",
-        "display": "Percentage blast cells (observable entity)"
+        "display": "Percentage blast cells"
       }
     ]
   },

--- a/Observation/Observation-Cellularity-Example.json
+++ b/Observation/Observation-Cellularity-Example.json
@@ -23,7 +23,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "75540009",
-        "display": "High (qualifier value)"
+        "display": "High"
       }
     ]
   },

--- a/Observation/Observation-CellularityKayBurbridge-Example.json
+++ b/Observation/Observation-CellularityKayBurbridge-Example.json
@@ -23,7 +23,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "75540009",
-        "display": "High (qualifier value)"
+        "display": "High"
       }
     ]
   },

--- a/Observation/Observation-CellularityPatrickSammy-Example.json
+++ b/Observation/Observation-CellularityPatrickSammy-Example.json
@@ -29,7 +29,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "75540009",
-        "display": "High (qualifier value)"
+        "display": "High"
       }
     ]
   },

--- a/Observation/Observation-DutchLipidScore-Example.json
+++ b/Observation/Observation-DutchLipidScore-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "872541000000104",
-        "display": "Dutch Lipid Clinic Network diagnostic criteria for familial hypercholesterolaemia score (observable entity)"
+        "display": "Dutch Lipid Clinic Network diagnostic criteria for familial hypercholesterolaemia score"
       }
     ],
     "text": "Dutch or (Welsh) Lipid score"

--- a/Observation/Observation-GenomicsVariantSLC52A2-Example.json
+++ b/Observation/Observation-GenomicsVariantSLC52A2-Example.json
@@ -35,6 +35,11 @@
       {
         "system": "http://loinc.org",
         "code": "69548-6"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "414755005",
+        "display": "Molecular, genetic AND/OR cellular observable"
       }
     ]
   },
@@ -56,6 +61,11 @@
         "system": "http://loinc.org",
         "code": "LA9633-4",
         "display": "Present"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "52101004",
+        "display": "Present"
       }
     ]
   },
@@ -65,6 +75,11 @@
         "system": "http://loinc.org",
         "code": "LA26398-0",
         "display": "Sequencing"
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "code": "117040002",
+        "display": "Nucleic acid sequencing"
       }
     ]
   },

--- a/Observation/Observation-HistoryOfFetalLoss-Example.json
+++ b/Observation/Observation-HistoryOfFetalLoss-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "161743003",
-        "display": "Past pregnancy history of stillbirth (situation)"
+        "display": "Past pregnancy history of stillbirth"
       }
     ],
     "text": "Is the testing for a fetal loss from 24+0 or more weeks of gestation?"

--- a/Observation/Observation-NatureAndAgeOfHearingLoss-Example.json
+++ b/Observation/Observation-NatureAndAgeOfHearingLoss-Example.json
@@ -27,7 +27,7 @@
 					{
 						"system": "http://snomed.info/sct",
 						"code": "95820000",
-						"display": "Bilateral hearing loss (disorder)"
+						"display": "Bilateral hearing loss"
 					}
 				]
 			},

--- a/Observation/Observation-Necrosis-Example.json
+++ b/Observation/Observation-Necrosis-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "405921002",
-        "display": "Percentage of neoplasm involved by necrosis (observable entity)"
+        "display": "Percentage of neoplasm involved by necrosis"
       }
     ]
   },

--- a/Observation/Observation-NecrosisKayBurbridge-Example.json
+++ b/Observation/Observation-NecrosisKayBurbridge-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "405921002",
-        "display": "Percentage of neoplasm involved by necrosis (observable entity)"
+        "display": "Percentage of neoplasm involved by necrosis"
       }
     ]
   },

--- a/Observation/Observation-NoBoneMarrowTransplant-Example.json
+++ b/Observation/Observation-NoBoneMarrowTransplant-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "416128008",
-        "display": "No history of procedure (situation)"
+        "display": "No history of procedure"
       }
     ]
   },
@@ -16,7 +16,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "445715009",
-        "display": "Blood and marrow transplantation (qualifier value)"
+        "display": "Blood and marrow transplantation"
       }
     ]
   },

--- a/Observation/Observation-NoBoneMarrowTransplantProbandFather-Example.json
+++ b/Observation/Observation-NoBoneMarrowTransplantProbandFather-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "416128008",
-        "display": "No history of procedure (situation)"
+        "display": "No history of procedure"
       }
     ]
   },
@@ -16,7 +16,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "445715009",
-        "display": "Blood and marrow transplantation (qualifier value)"
+        "display": "Blood and marrow transplantation"
       }
     ]
   },

--- a/Observation/Observation-NoBoneMarrowTransplantProbandMother-Example.json
+++ b/Observation/Observation-NoBoneMarrowTransplantProbandMother-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "416128008",
-        "display": "No history of procedure (situation)"
+        "display": "No history of procedure"
       }
     ]
   },
@@ -16,7 +16,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "445715009",
-        "display": "Blood and marrow transplantation (qualifier value)"
+        "display": "Blood and marrow transplantation"
       }
     ]
   },

--- a/Observation/Observation-NoPregnancy-Example.json
+++ b/Observation/Observation-NoPregnancy-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "60001007",
-        "display": "Not pregnant (finding)"
+        "display": "Not pregnant"
       }
     ]
   },

--- a/Observation/Observation-NoTransfusion-Example.json
+++ b/Observation/Observation-NoTransfusion-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "416128008",
-        "display": "No history of procedure (situation)"
+        "display": "No history of procedure"
       }
     ]
   },
@@ -16,7 +16,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "303955003",
-        "display": "Transfusion - action (qualifier value)"
+        "display": "Transfusion - action"
       }
     ]
   },

--- a/Observation/Observation-NoTransfusionProbandFather-Example.json
+++ b/Observation/Observation-NoTransfusionProbandFather-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "416128008",
-        "display": "No history of procedure (situation)"
+        "display": "No history of procedure"
       }
     ]
   },
@@ -16,7 +16,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "303955003",
-        "display": "Transfusion - action (qualifier value)"
+        "display": "Transfusion - action"
       }
     ]
   },

--- a/Observation/Observation-NoTransfusionProbandMother-Example.json
+++ b/Observation/Observation-NoTransfusionProbandMother-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "416128008",
-        "display": "No history of procedure (situation)"
+        "display": "No history of procedure"
       }
     ]
   },
@@ -16,7 +16,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "303955003",
-        "display": "Transfusion - action (qualifier value)"
+        "display": "Transfusion - action"
       }
     ]
   },

--- a/Observation/Observation-NoTransplant-Example.json
+++ b/Observation/Observation-NoTransplant-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "416128008",
-        "display": "No history of procedure (situation)"
+        "display": "No history of procedure"
       }
     ]
   },
@@ -16,7 +16,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "263903005",
-        "display": "Transplant (qualifier value)"
+        "display": "Transplant"
       }
     ]
   },

--- a/Observation/Observation-NonConsanguinousUnion-Example.json
+++ b/Observation/Observation-NonConsanguinousUnion-Example.json
@@ -7,7 +7,7 @@
 			{
 				"system": "http://snomed.info/sct",
 				"code": "160475008",
-				"display": "Family history: Consanguinity (situation)"
+				"display": "Family history: Consanguinity"
 			}
 		]
 	},

--- a/Observation/Observation-NonConsanguinousUnionProband-Example.json
+++ b/Observation/Observation-NonConsanguinousUnionProband-Example.json
@@ -7,7 +7,7 @@
 			{
 				"system": "http://snomed.info/sct",
 				"code": "160475008",
-				"display": "Family history: Consanguinity (situation)"
+				"display": "Family history: Consanguinity"
 			}
 		]
 	},

--- a/Observation/Observation-NonConsanguinousUnionProbandFather-Example.json
+++ b/Observation/Observation-NonConsanguinousUnionProbandFather-Example.json
@@ -7,7 +7,7 @@
 			{
 				"system": "http://snomed.info/sct",
 				"code": "160475008",
-				"display": "Family history: Consanguinity (situation)"
+				"display": "Family history: Consanguinity"
 			}
 		]
 	},

--- a/Observation/Observation-NonConsanguinousUnionProbandMother-Example.json
+++ b/Observation/Observation-NonConsanguinousUnionProbandMother-Example.json
@@ -7,7 +7,7 @@
 			{
 				"system": "http://snomed.info/sct",
 				"code": "160475008",
-				"display": "Family history: Consanguinity (situation)"
+				"display": "Family history: Consanguinity"
 			}
 		]
 	},

--- a/Observation/Observation-PatrickSammyNoBoneMarrowTransplant-Example.json
+++ b/Observation/Observation-PatrickSammyNoBoneMarrowTransplant-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "416128008",
-        "display": "No history of procedure (situation)"
+        "display": "No history of procedure"
       }
     ]
   },
@@ -16,7 +16,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "445715009",
-        "display": "Blood and marrow transplantation (qualifier value)"
+        "display": "Blood and marrow transplantation"
       }
     ]
   },

--- a/Observation/Observation-PercentageMalignantNuclei-Example.json
+++ b/Observation/Observation-PercentageMalignantNuclei-Example.json
@@ -6,8 +6,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "1255076007",
-        "display": "Percent of cell nuclei positive for proliferation marker protein Ki-67 in primary malignant neoplasm of stomach by immunohistochemistry (observable entity)"
+        "code": "1015521000000107",
+        "display": "Percentage blast cells"
       }
     ]
   },

--- a/Observation/Observation-TumourType-Example.json
+++ b/Observation/Observation-TumourType-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "14799000",
-        "display": "Neoplasm, metastatic (morphologic abnormality)"
+        "display": "Neoplasm, metastatic"
       }
     ]
   },

--- a/Observation/Observation-TumourTypeDemeizaSeo-Example.json
+++ b/Observation/Observation-TumourTypeDemeizaSeo-Example.json
@@ -6,8 +6,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "116061001",
-        "display": "Solid pseudopapillary carcinoma (morphologic abnormality)"
+        "code": "369757002",
+        "display": "Solid tumor configuration"
       }
     ]
   },

--- a/Observation/Observation-TumourTypeKayBurbridge-Example.json
+++ b/Observation/Observation-TumourTypeKayBurbridge-Example.json
@@ -7,7 +7,7 @@
       {
         "system": "http://snomed.info/sct",
         "code": "14799000",
-        "display": "Neoplasm, metastatic (morphologic abnormality)"
+        "display": "Neoplasm, metastatic"
       }
     ]
   },

--- a/Observation/Observation-UnknownConsanguinousUnionStatus-Example.json
+++ b/Observation/Observation-UnknownConsanguinousUnionStatus-Example.json
@@ -7,7 +7,7 @@
 			{
 				"system": "http://snomed.info/sct",
 				"code": "160475008",
-				"display": "Family history: Consanguinity (situation)"
+				"display": "Family history: Consanguinity"
 			}
 		]
 	},

--- a/ServiceRequest/ServiceRequest-NonWGSTestOrderForm-Cancellation-Example.json
+++ b/ServiceRequest/ServiceRequest-NonWGSTestOrderForm-Cancellation-Example.json
@@ -84,7 +84,7 @@
   ],
   "specimen": [
     {
-      "display": "Specimen/Specimen-BloodEDTA-Example"
+      "reference": "Specimen/Specimen-BloodEDTA-Example"
     }
   ],
   "note": [

--- a/ServiceRequest/ServiceRequest-NonWGSTestOrderFormUpdated-Cancellation-Example.json
+++ b/ServiceRequest/ServiceRequest-NonWGSTestOrderFormUpdated-Cancellation-Example.json
@@ -88,7 +88,7 @@
   ],
   "specimen": [
     {
-      "display": "Specimen/Specimen-BloodEDTA-Example"
+      "reference": "Specimen/Specimen-BloodEDTA-Example"
     }
   ],
   "note": [

--- a/Specimen/Specimen-BloodEDTA-Example.json
+++ b/Specimen/Specimen-BloodEDTA-Example.json
@@ -12,8 +12,8 @@
 		"coding": [
 			{
 				"system": "http://snomed.info/sct",
-				"code": "445295009",
-				"display": "Blood specimen with EDTA"
+				"code": "119297000",
+				"display": "Blood specimen"
 			}
 		]
 	},

--- a/Specimen/Specimen-BloodEDTA-WithCollectionDetails-Example.json
+++ b/Specimen/Specimen-BloodEDTA-WithCollectionDetails-Example.json
@@ -12,8 +12,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "445295009",
-        "display": "Blood specimen with EDTA"
+				"code": "119297000",
+				"display": "Blood specimen"
       }
     ]
   },

--- a/Specimen/Specimen-JamesMetcalfeBloodEDTA-Example.json
+++ b/Specimen/Specimen-JamesMetcalfeBloodEDTA-Example.json
@@ -26,8 +26,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "445295009",
-        "display": "Blood specimen with EDTA"
+				"code": "119297000",
+				"display": "Blood specimen"
       }
     ]
   },

--- a/Specimen/Specimen-MichaelJonesBlood-Example.json
+++ b/Specimen/Specimen-MichaelJonesBlood-Example.json
@@ -10,8 +10,8 @@
 		"coding": [
 			{ 
 				"system": "http://snomed.info/sct", 
-				"code": "87612001", 
-				"display": "Blood (substance)"
+				"code": "119297000", 
+				"display": "Blood specimen"
 			}
 		]
 	},

--- a/Specimen/Specimen-MichaelJonesBloodWithCollectionDetails-Example.json
+++ b/Specimen/Specimen-MichaelJonesBloodWithCollectionDetails-Example.json
@@ -16,8 +16,8 @@
 		"coding": [
 			{ 
 				"system": "http://snomed.info/sct", 
-				"code": "87612001", 
-				"display": "Blood (substance)"
+				"code": "119297000", 
+				"display": "Blood specimen"
 			}
 		]
 	},
@@ -54,7 +54,7 @@
 				{
 					"system": "http://snomed.info/sct", 
 					"code": "14975008", 
-					"display": "Forearm structure (body structure)"
+					"display": "Forearm structure"
 				}
 			]
 		}
@@ -85,7 +85,7 @@
 					{
 						"system": "http://snomed.info/sct", 
 						"code": "706067003", 
-						"display": "Blood collection/transfer device (physical object)"
+						"display": "Blood collection/transfer device"
 					}
 				]
 			},

--- a/Specimen/Specimen-PatrickSammyBloodEDTA-Example.json
+++ b/Specimen/Specimen-PatrickSammyBloodEDTA-Example.json
@@ -26,8 +26,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "445295009",
-        "display": "Blood specimen with EDTA"
+				"code": "119297000",
+				"display": "Blood specimen"
       }
     ]
   },

--- a/Specimen/Specimen-PheobeSmitham-Example.json
+++ b/Specimen/Specimen-PheobeSmitham-Example.json
@@ -26,8 +26,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "445295009",
-        "display": "Blood specimen with EDTA"
+				"code": "119297000",
+				"display": "Blood specimen"
       }
     ]
   },

--- a/Specimen/Specimen-PheobeSmithamFather-Example.json
+++ b/Specimen/Specimen-PheobeSmithamFather-Example.json
@@ -26,8 +26,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "445295009",
-        "display": "Blood specimen with EDTA"
+				"code": "119297000",
+				"display": "Blood specimen"
       }
     ]
   },

--- a/Specimen/Specimen-PheobeSmithamMother-Example.json
+++ b/Specimen/Specimen-PheobeSmithamMother-Example.json
@@ -26,8 +26,8 @@
     "coding": [
       {
         "system": "http://snomed.info/sct",
-        "code": "445295009",
-        "display": "Blood specimen with EDTA"
+				"code": "119297000",
+				"display": "Blood specimen"
       }
     ]
   },

--- a/Task/UKCore-Task-DPYDSequencingTask-Example.json
+++ b/Task/UKCore-Task-DPYDSequencingTask-Example.json
@@ -61,7 +61,7 @@
 				{ 
 					"system": "http://snomed.info/sct", 
 					"code": "159282002", 
-					"display": "Laboratory technician (occupation)"
+					"display": "Laboratory technician"
 				}
 			]
 		}


### PR DESCRIPTION
Various fixes to SNOMED terms in examples and concept maps

- Removal of semantic tag so preferred term is used instead of FSN
- Correction to blood specimen codes used to match concept map
- Change to the solid tumour type concept map to make this more accurate when used in Observations
- Corrections to examples where codes were incorrectly used
- Addition of SNOMED codes alongside LOINC codes in Structured Reporting examples, where equivalent codes existed.