### PR TITLE
Representing Negative Findings

### DIFF
--- a/Observation/Observation-SLC52A2-VariantAbsent-Example.json
+++ b/Observation/Observation-SLC52A2-VariantAbsent-Example.json
@@ -21,7 +21,17 @@
   }
  ],
  "code": {
-  "text": "SLC52A2 variant assessment"
+  "coding": [
+   {
+    "system": "http://loinc.org",
+    "code": "69548-6"
+   },
+   {
+    "system": "http://snomed.info/sct",
+    "code": "414755005",
+    "display": "Molecular, genetic AND/OR cellular observable"
+   }
+  ]
  },
  "subject": {
   "reference": "Patient/Patient-PheobeSmitham-Example"

--- a/Observation/Observation-SLC52A2-VariantAbsent-Example.json
+++ b/Observation/Observation-SLC52A2-VariantAbsent-Example.json
@@ -24,7 +24,8 @@
   "coding": [
    {
     "system": "http://loinc.org",
-    "code": "69548-6"
+    "code": "69548-6",
+    "display": "Genetic variant assessment"
    },
    {
     "system": "http://snomed.info/sct",

--- a/Observation/Observation-SLC52A2-VariantAbsent-Example.json
+++ b/Observation/Observation-SLC52A2-VariantAbsent-Example.json
@@ -1,0 +1,56 @@
+{
+ "resourceType": "Observation",
+ "id": "Observation-SLC52A2-VariantAbsent-Example",
+ "status": "final",
+ "category": [
+  {
+   "coding": [
+    {
+     "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+     "code": "laboratory"
+    }
+   ]
+  },
+  {
+   "coding": [
+    {
+     "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+     "code": "GE"
+    }
+   ]
+  }
+ ],
+ "code": {
+  "text": "SLC52A2 variant assessment"
+ },
+ "subject": {
+  "reference": "Patient/Patient-PheobeSmitham-Example"
+ },
+ "effectiveDateTime": "2023-09-16",
+ "valueCodeableConcept": {
+  "coding": [
+   {
+    "system": "http://snomed.info/sct",
+    "code": "260415000",
+    "display": "Not detected"
+   },
+   {
+    "system": "http://loinc.org",
+    "code": "LA9634-2",
+    "display": "Absent"
+   }
+  ],
+  "text": "Variant not detected"
+ },
+ "method": [
+  {
+   "coding": [
+    {
+     "system": "http://snomed.info/sct",
+     "code": "117040002",
+     "display": "Nucleic acid sequencing"
+    }
+   ]
+  }
+ ]
+}

--- a/Observation/Observation-SeizurePhenotypeAbsent-Example.json
+++ b/Observation/Observation-SeizurePhenotypeAbsent-Example.json
@@ -15,7 +15,8 @@
  "code": {
   "coding": [
    {
-    "system": "http://purl.obolibrary.org/obo/hp.owl",
+    "system": "http://human-phenotype-ontology.org",
+    "version": "20221005",
     "code": "HP:0001250",
     "display": "Seizure"
    }

--- a/Observation/Observation-SeizurePhenotypeAbsent-Example.json
+++ b/Observation/Observation-SeizurePhenotypeAbsent-Example.json
@@ -1,0 +1,43 @@
+{
+ "resourceType": "Observation",
+ "id": "Observation-SeizurePhenotypeAbsent-Example",
+ "status": "final",
+ "category": [
+  {
+   "coding": [
+    {
+     "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+     "code": "exam"
+    }
+   ]
+  }
+ ],
+ "code": {
+  "coding": [
+   {
+    "system": "http://purl.obolibrary.org/obo/hp.owl",
+    "code": "HP:0001250",
+    "display": "Seizure"
+   }
+  ]
+ },
+ "subject": {
+  "reference": "Patient/Patient-PheobeSmitham-Example"
+ },
+ "effectiveDateTime": "2023-09-16",
+ "valueCodeableConcept": {
+  "coding": [
+   {
+    "system": "http://snomed.info/sct",
+    "code": "260415000",
+    "display": "Not detected"
+   },
+   {
+    "system": "http://loinc.org",
+    "code": "LA9634-2",
+    "display": "Absent"
+   }
+  ],
+  "text": "Phenotype not present"
+ }
+}


### PR DESCRIPTION
Representation of Negative Findings
Where a qualitative laboratory results or genomic observation represents the presence or absence of a specific variant or phenotypic feature, Observation.code SHALL identify the observation being assessed (e.g., a genomic variant, or a phenotypic feature), while Observation.valueCodeableConcept SHALL convey the outcome of that assessment. 
A negative finding SHOULD be represented using an appropriate coded concept from the terminology system adopted by the implementation (e.g., SNOMED CT, such as Negative, Absent, Not Detected or Non-reactive).
Phenotypic details or supporting clinical characteristics, Variant-specific details, including HGVS expressions, genomic coordinates, zygosity, molecular consequence, and other characteristics of the variant, SHALL only be populated when the corresponding variant has been identified.

Observation.interpretation MAY be used to provide additional clinical interpretation of the finding.
However, Observation.interpretation SHALL NOT be used as the sole representation of the result and SHALL NOT replace the actual result value carried in Observation.value[x]
